### PR TITLE
add ability to not evaluate events until service is warm

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
     {
       "name": "pipeline1",
       "max_seconds_to_reach_end": 10,
+      "seconds_from_startup_to_ignore_event_evaluation": 0,
       "services": [
         {
           "name": "step1",
@@ -22,6 +23,7 @@
     {
       "name": "pipeline2",
       "max_seconds_to_reach_end": 10,
+      "seconds_from_startup_to_ignore_event_evaluation": 0,
       "services": [
         {
           "name": "step2",

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Pipeline {
     pub name: String,
-    pub max_seconds_to_reach_end: u64,
+    pub max_seconds_to_reach_end: i64,
+    pub seconds_from_startup_to_ignore_event_evaluation: i64,
     pub services: Vec<Service>,
 }
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -88,7 +88,7 @@ fn process(pipeline: Pipeline, recv: Receiver<EventBatch>) {
                     if expire_at < now {
                       expire_until_idx = i as isize;
 
-                      if now <= start_evaluating_events_at as u32{
+                      if ev.timestamp <= start_evaluating_events_at as u32{
                           // To stop a flood of erroneous logs/alerts during startup when not all
                           // events may have been reported, we simply don't evaluate or log events
                           // during the time window specified in the config.


### PR DESCRIPTION
This PR fixes issue #3 , which describes the case when nomarch starts up and events that are partially through a pipeline do not have earlier steps reported.  This causes a flood of erroneous notifications/logging.

To fix this issue we add a config option `seconds_from_startup_to_ignore_event_evaluation` which allows a user to specify how many seconds after nomarch starts up an event be _initially reported_ by for nomarch to evaluate and log it's result.  Again, this is based on the time of each event's first reporting to nomarch, and not the time that expiration runs.