### PR TITLE
Automatically detect grace period

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,6 @@
     {
       "name": "pipeline1",
       "max_seconds_to_reach_end": 10,
-      "seconds_from_startup_to_ignore_event_evaluation": 0,
       "services": [
         {
           "name": "step1",
@@ -23,7 +22,6 @@
     {
       "name": "pipeline2",
       "max_seconds_to_reach_end": 10,
-      "seconds_from_startup_to_ignore_event_evaluation": 0,
       "services": [
         {
           "name": "step2",

--- a/src/grace_period.rs
+++ b/src/grace_period.rs
@@ -1,0 +1,51 @@
+const REQUIRED_SUCCESS_COUNT: usize = 3;
+
+/// The Grace Period Detector determines if an event that is being expired falls within the grace
+/// period or not. This is to eliminate the false negatives for events partially reported due to
+/// Nomarch starting while they were already part way through the pipeline.
+///
+/// The Grace Period is at most the length of the Pipeline's `max_seconds_to_reach_end` config
+/// value. But if REQUIRED_SUCCESS_COUNT ticks complete, each with 0 incomplete events and at least
+/// 1 event expired during the tick, then we consider the system healthy and short-circuit the
+/// Grace Period.
+///
+/// If the Grace Period successfully short circuits, then calls to register_unsuccessful_tick will
+/// not re-enable it.
+///
+/// This makes sure people see results as quickly as possible, without having to configure a
+/// fallible heuristic to control the delay in reporting.
+pub struct Detector {
+    success_count: usize,
+    timeout_timestamp: i64,
+}
+
+impl Detector {
+    pub fn new(timeout_timestamp: i64) -> Self {
+        Self {
+            success_count: 0,
+            timeout_timestamp,
+        }
+    }
+
+    pub fn register_successful_tick(&mut self) {
+        if self.success_count < REQUIRED_SUCCESS_COUNT {
+            self.success_count += 1;
+        }
+    }
+
+    pub fn register_unsuccessful_tick(&mut self) {
+        // Unsuccessful ticks should only reset things if the Grace Perod hasn't been short
+        // circuited.
+        if self.success_count < REQUIRED_SUCCESS_COUNT {
+            self.success_count = 0
+        }
+    }
+
+    pub fn within_grace_period(&self, event_timestamp: u32) -> bool {
+        if self.success_count >= REQUIRED_SUCCESS_COUNT {
+            return false;
+        }
+
+        event_timestamp as i64 <= self.timeout_timestamp
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ extern crate log;
 extern crate crossbeam_channel;
 
 mod config;
+mod grace_period;
 mod pipeline;
 mod processor;
 
@@ -100,9 +101,8 @@ async fn main() -> std::io::Result<()> {
             .service(health_handler)
             .service(event_handler)
             .app_data(
-                web::JsonConfig::default()
-                    .limit(524288) // Limit request payload size
-                )
+                web::JsonConfig::default().limit(524288), // Limit request payload size
+            )
     })
     .bind("0.0.0.0:8080")?
     .run()

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 pub struct Pipeline {
     pub name: String,
     pub max_seconds_to_reach_end: i64,
-    pub seconds_from_startup_to_ignore_event_evaluation: i64,
     pub services: Vec<Service>,
 }
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,3 +1,4 @@
+use crate::grace_period;
 use crate::pipeline::Pipeline;
 use chrono::Utc;
 use crossbeam_channel::{bounded, tick, Receiver, Sender};
@@ -47,8 +48,8 @@ fn process(pipeline: Pipeline, recv: Receiver<EventBatch>) {
     // Used to batch incoming events that will be applied to the full events list on tick.
     let mut event_set: HashMap<u128, Event> = HashMap::new();
 
-    let start_evaluating_events_at =
-        Utc::now().timestamp() + pipeline.seconds_from_startup_to_ignore_event_evaluation;
+    let mut grace_period =
+        grace_period::Detector::new(Utc::now().timestamp() + pipeline.max_seconds_to_reach_end);
 
     let ticker = tick(Duration::from_secs(1));
     loop {
@@ -67,11 +68,14 @@ fn process(pipeline: Pipeline, recv: Receiver<EventBatch>) {
                 }
             },
             recv(ticker) -> _ => {
-                let now = Utc::now().timestamp() as u32;
+                let now = Utc::now().timestamp();
 
                 // Keep track of added and updated events from event_set for logging purposes
                 let mut added = 0;
                 let mut updated = 0;
+
+                // Keep track of incomplete ticks for grace period short circuiting
+                let mut incomplete = 0;
 
                 let mut expire_until_idx: isize = -1;
                 for (i, ev) in events.iter_mut().enumerate() {
@@ -85,20 +89,13 @@ fn process(pipeline: Pipeline, recv: Receiver<EventBatch>) {
                             updated += 1;
                     }
 
-                    if expire_at < now {
+                    if expire_at < now as u32 {
                       expire_until_idx = i as isize;
 
-                      if ev.timestamp <= start_evaluating_events_at as u32{
-                          // To stop a flood of erroneous logs/alerts during startup when not all
-                          // events may have been reported, we simply don't evaluate or log events
-                          // during the time window specified in the config.
-                        continue
-                      }
-
-                      if ev.services == complete || (ev.services & required) == required {
-                        info!("event id {:?} completed pipeline {:?} : {:#018b}", Uuid::from_u128(ev.id), pipeline.name, ev.services);
-                      } else {
-                        info!("event id {:?} did not complete pipeline {:?} : {:#018b}", Uuid::from_u128(ev.id), pipeline.name, ev.services);
+                      let event_complete = ev.services == complete || (ev.services & required) == required;
+                      report_event_status(ev, &*pipeline.name, event_complete, grace_period.within_grace_period(ev.timestamp));
+                      if !event_complete {
+                        incomplete += 1;
                       }
                     }
                 }
@@ -119,6 +116,12 @@ fn process(pipeline: Pipeline, recv: Receiver<EventBatch>) {
                   info!("expired {:?} events, added {:?} events, updated {:?} events for pipeline {:?}", expired, added, updated, pipeline.name);
                 }
 
+                if incomplete == 0 && expired > 0 {
+                    grace_period.register_successful_tick();
+                } else {
+                    grace_period.register_unsuccessful_tick();
+                }
+
                 // nothing to expire yet
                 if expire_until_idx < 0 {
                     continue
@@ -127,5 +130,26 @@ fn process(pipeline: Pipeline, recv: Receiver<EventBatch>) {
                 events = events.split_off(expire_until_idx as usize + 1);
             },
         }
+    }
+}
+
+fn report_event_status(ev: &Event, pipeline: &str, complete: bool, in_grace_period: bool) {
+    if in_grace_period {
+        info!("skipping because in grace_period");
+        return;
+    }
+
+    let uuid = Uuid::from_u128(ev.id);
+
+    if complete {
+        info!(
+            "event id {:?} completed pipeline {:?} : {:#018b}",
+            uuid, pipeline, ev.services
+        );
+    } else {
+        info!(
+            "event id {:?} did not complete pipeline {:?} : {:#018b}",
+            uuid, pipeline, ev.services
+        );
     }
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -135,7 +135,6 @@ fn process(pipeline: Pipeline, recv: Receiver<EventBatch>) {
 
 fn report_event_status(ev: &Event, pipeline: &str, complete: bool, in_grace_period: bool) {
     if in_grace_period {
-        info!("skipping because in grace_period");
         return;
     }
 


### PR DESCRIPTION
An issue that nomarch had is that when a system is reporting events to nomarch, but nomarch had just been started, events partially through the pipeline would only be partially reported. This would lead to an immediate flood of false negatives that would die down quickly as new data would be completely reported.

This issue was brought up in #3 and fixed in PR #5 by introducing a config option to specify a grace period.  However, almost immediately after the PR was merged I got to talking to Ori_B on the lobsters IRC channel and we worked out a better way to do this that wouldn't require a config option at all!

The idea is that the Grace Period could last for up to the length of a single Pipeline `max_seconds_to_reach_end`. That way, if something is really broken and dropping tons of stuff then after that initial period ends you'd get a bunch of legitimate alerts. However, if we detect at least `REQUIRED_SUCCESS_COUNT` number of ticks where at least 1 event is expired and it has a 100% pipeline completion rate within the tick, then we will short circuit the Grace Period so that you can get results faster.

Right now, `REQUIRED_SUCCESS_COUNT` is hardcoded as 3 in `src/grace_period.rs` and is not exposed as a config option.  I don't believe we will need to expose it, but I'm open to it if any users report problems with it.

cc: @AndrewScibek because it's changing what we talked about in the issue you raised.