### PR TITLE
Switch grace period/overall event checking method

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "pipelines": [
     {
       "name": "pipeline1",
-      "max_seconds_to_reach_end": 10,
+      "max_seconds_to_reach_end": 18000,
       "services": [
         {
           "name": "step1",

--- a/src/grace_period.rs
+++ b/src/grace_period.rs
@@ -1,16 +1,14 @@
-const REQUIRED_SUCCESS_COUNT: usize = 3;
+// Total Successful ticks(not events) needed
+const REQUIRED_SUCCESS_TICK: usize = 3;
 
 /// The Grace Period Detector determines if an event that is being expired falls within the grace
 /// period or not. This is to eliminate the false negatives for events partially reported due to
 /// Nomarch starting while they were already part way through the pipeline.
 ///
 /// The Grace Period is at most the length of the Pipeline's `max_seconds_to_reach_end` config
-/// value. But if REQUIRED_SUCCESS_COUNT ticks complete, each with 0 incomplete events and at least
+/// value. But if REQUIRED_SUCCESS_TICK(s) complete, each with at least 1 complete events and at least
 /// 1 event expired during the tick, then we consider the system healthy and short-circuit the
 /// Grace Period.
-///
-/// If the Grace Period successfully short circuits, then calls to register_unsuccessful_tick will
-/// not re-enable it.
 ///
 /// This makes sure people see results as quickly as possible, without having to configure a
 /// fallible heuristic to control the delay in reporting.
@@ -28,21 +26,13 @@ impl Detector {
     }
 
     pub fn register_successful_tick(&mut self) {
-        if self.success_count < REQUIRED_SUCCESS_COUNT {
+        if self.success_count < REQUIRED_SUCCESS_TICK {
             self.success_count += 1;
         }
     }
 
-    pub fn register_unsuccessful_tick(&mut self) {
-        // Unsuccessful ticks should only reset things if the Grace Perod hasn't been short
-        // circuited.
-        if self.success_count < REQUIRED_SUCCESS_COUNT {
-            self.success_count = 0
-        }
-    }
-
     pub fn within_grace_period(&self, event_timestamp: u32) -> bool {
-        if self.success_count >= REQUIRED_SUCCESS_COUNT {
+        if self.success_count >= REQUIRED_SUCCESS_TICK {
             return false;
         }
 

--- a/src/grace_period.rs
+++ b/src/grace_period.rs
@@ -1,13 +1,12 @@
-// Total Successful ticks(not events) needed
-const REQUIRED_SUCCESS_TICK: usize = 3;
+// Total Successful  events needed
+const REQUIRED_SUCCESS_EVENTS: usize = 3;
 
 /// The Grace Period Detector determines if an event that is being expired falls within the grace
 /// period or not. This is to eliminate the false negatives for events partially reported due to
 /// Nomarch starting while they were already part way through the pipeline.
 ///
 /// The Grace Period is at most the length of the Pipeline's `max_seconds_to_reach_end` config
-/// value. But if REQUIRED_SUCCESS_TICK(s) complete, each with at least 1 complete events and at least
-/// 1 event expired during the tick, then we consider the system healthy and short-circuit the
+/// value. But if REQUIRED_SUCCESS_EVENTS(s) complete, then we consider the system healthy and short-circuit the
 /// Grace Period.
 ///
 /// This makes sure people see results as quickly as possible, without having to configure a
@@ -25,14 +24,14 @@ impl Detector {
         }
     }
 
-    pub fn register_successful_tick(&mut self) {
-        if self.success_count < REQUIRED_SUCCESS_TICK {
+    pub fn register_successful_event(&mut self) {
+        if self.success_count <= REQUIRED_SUCCESS_EVENTS {
             self.success_count += 1;
         }
     }
 
     pub fn within_grace_period(&self, event_timestamp: u32) -> bool {
-        if self.success_count >= REQUIRED_SUCCESS_TICK {
+        if self.success_count > REQUIRED_SUCCESS_EVENTS {
             return false;
         }
 


### PR DESCRIPTION
Currently grace period checking isn't working because it doesn't check events until they expire.

This PR is a proposal of how to get around that. Instead of waiting the entire expire time, nomarch would mark the event as complete, log the event, and then do a retain all non complete ids. 